### PR TITLE
🐛 Fix connect lock issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reedsy/reconnecting-websocket",
-    "version": "4.4.0-reedsy-1.0.0",
+    "version": "4.4.0-reedsy-1.0.1",
     "description": "Reconnecting WebSocket",
     "main": "./dist/reconnecting-websocket-cjs.js",
     "module": "./dist/reconnecting-websocket-mjs.js",

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -351,7 +351,6 @@ export default class ReconnectingWebSocket {
         if (this._connectLock || !this._shouldReconnect) {
             return;
         }
-        this._connectLock = true;
 
         const {
             maxRetries = DEFAULT.maxRetries,
@@ -364,6 +363,7 @@ export default class ReconnectingWebSocket {
             return;
         }
 
+        this._connectLock = true;
         this._retryCount++;
 
         this._debug('connect', this._retryCount);
@@ -376,6 +376,7 @@ export default class ReconnectingWebSocket {
             .then(url => {
                 // close could be called before creating the ws
                 if (this._closeCalled) {
+                    this._connectLock = false;
                     return;
                 }
                 this._debug('connect', {url, protocols: this._protocols});


### PR DESCRIPTION
This change fixes two issues described here:
https://github.com/pladaria/reconnecting-websocket/issues/165

 1. It's impossible to reconnect after `maxRetries` is exceeded, because the lock is never released
 2. It's impossible to reconnect if `close()` was called before the connection has been established

This change adds tests and fixes as discussed in the above issue.