### PR TITLE
🐛 Run close handler if `ws.close()` throws

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reedsy/reconnecting-websocket",
-    "version": "4.4.0-reedsy-1.0.1",
+    "version": "4.4.0-reedsy-1.0.2",
     "description": "Reconnecting WebSocket",
     "main": "./dist/reconnecting-websocket-cjs.js",
     "module": "./dist/reconnecting-websocket-mjs.js",

--- a/reconnecting-websocket.ts
+++ b/reconnecting-websocket.ts
@@ -404,10 +404,10 @@ export default class ReconnectingWebSocket {
         this._removeListeners();
         try {
             this._ws.close(code, reason);
-            this._handleClose(new Events.CloseEvent(code, reason, this));
         } catch (error) {
-            // ignore
+            this._debug('swallowing disconnect error', error);
         }
+        this._handleClose(new Events.CloseEvent(code, reason, this));
     }
 
     private _acceptOpen() {


### PR DESCRIPTION
At the moment, when calling the internal method `_disconnect()` (triggered by calling `reconnect()` for example), `ReconnectingSocket` swallows any errors thrown by `_ws.close()`.

Such errors might include trying to close while the socket is still connecting, for example, which is an [expected][1], but uninteresting error (and should rightfully be swallowed).

Since the `_handleClose()` method is included in the `try`/`catch` block, the close handler isn't called when an error like this occurs.

The downstream effect of this is that clients may get "invalid"-looking transitions with a socket that never seems to close.

In our particular case, `sharedb` complains about transitioning from `connected` to `connecting` (since the close handler was never fired, so we skip right past the `closed` state).

This change moves the close handler outside of this `try`/`catch`, so that the handler is called even if the `close()` call throws.

It is a bit strange to call this handler when the socket may be in a strange state - it has errored whilst closing, so the socket will probably not be in a `closed` state during the `close` event callback. However:

 - the existing behaviour is already a bit inconsistent: the close handlers are called synchronously after calling `ws.close()`, where - even if the socket doesn't throw - the socket's state will be `closing` (since it's waiting for the server to complete the close handshake)
 - `_disconnect()` is only called from two places:
   1. [`reconnect()`][2], after which we'll immediately call `connect()` so we'll be replacing our socket imminently anyway
   2. [`_handleError()`][3] where we might already expect the socket to be in an odd state, and where we may be about to fire error handlers anyway

[1]: https://websockets.spec.whatwg.org/#interface-definition
[2]: https://github.com/reedsy/reconnecting-websocket/blob/94fff5d69eb725d4512464371a54ac2806c641c4/reconnecting-websocket.ts#L244
[3]: https://github.com/reedsy/reconnecting-websocket/blob/94fff5d69eb725d4512464371a54ac2806c641c4/reconnecting-websocket.ts#L461